### PR TITLE
修复插件重载后无法正常工作

### DIFF
--- a/mcdreforged.plugin.json
+++ b/mcdreforged.plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "where_is",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "name": "Where Is",
     "description":  {
         "en_us": "Query players' coordinates",

--- a/where_is/online_players.py
+++ b/where_is/online_players.py
@@ -59,6 +59,7 @@ class OnlinePlayers:
                     psi.logger.warning(
                         "Incorrect player count found while refreshing player list"
                     )
+            self.__enabled = True
 
     @named_thread
     def __enable_player_join(self):
@@ -67,24 +68,16 @@ class OnlinePlayers:
             debug("Player list counting enabled")
 
     @named_thread
-    def __disable_player_join(self):
-        with self.__lock:
-            self.__enabled = False
-            debug("Player list counting disable")
-
-    @named_thread
     def __clear_online_players(self):
         with self.__lock:
+            self.__enabled = False
             self.__limit, self.__players = None, []
             debug("Cleared online player cache")
 
     def register_event_listeners(self):
         psi.register_event_listener(
             MCDRPluginEvents.PLUGIN_LOADED,
-            lambda *args, **kwargs: (
-                self.__refresh_online_players(),
-                self.__enable_player_join() if psi.is_server_startup() else None
-            ),
+            lambda *args, **kwargs: self.__refresh_online_players()
         )
         psi.register_event_listener(
             MCDRPluginEvents.SERVER_STARTUP,
@@ -101,7 +94,6 @@ class OnlinePlayers:
             MCDRPluginEvents.SERVER_STOP,
             lambda *args, **kwargs: (
                 self.__clear_online_players(),
-                self.__disable_player_join()
             ),
         )
 

--- a/where_is/online_players.py
+++ b/where_is/online_players.py
@@ -67,6 +67,12 @@ class OnlinePlayers:
             debug("Player list counting enabled")
 
     @named_thread
+    def __disable_player_join(self):
+        with self.__lock:
+            self.__enabled = False
+            debug("Player list counting disable")
+
+    @named_thread
     def __clear_online_players(self):
         with self.__lock:
             self.__limit, self.__players = None, []
@@ -75,10 +81,13 @@ class OnlinePlayers:
     def register_event_listeners(self):
         psi.register_event_listener(
             MCDRPluginEvents.PLUGIN_LOADED,
-            lambda *args, **kwargs: self.__refresh_online_players(),
+            lambda *args, **kwargs: (
+                self.__refresh_online_players(),
+                self.__enable_player_join() if psi.is_server_startup() else None
+            ),
         )
         psi.register_event_listener(
-            MCDRPluginEvents.SERVER_START,
+            MCDRPluginEvents.SERVER_STARTUP,
             lambda *args, **kwargs: self.__enable_player_join(),
         )
         psi.register_event_listener(
@@ -90,7 +99,10 @@ class OnlinePlayers:
         )
         psi.register_event_listener(
             MCDRPluginEvents.SERVER_STOP,
-            lambda *args, **kwargs: self.__clear_online_players(),
+            lambda *args, **kwargs: (
+                self.__clear_online_players(),
+                self.__disable_player_join()
+            ),
         )
 
 


### PR DESCRIPTION
此bug疑似 https://github.com/Lazy-Bing-Server/WhereIs-MCDR/issues/6 的真正原因

## 复现
1. 安装插件后启动mcdr与服务器,
2. 确保服务器内无人, `!!MCDR plg ra` 重载插件

此时进入服务器, `!!here`等功能已无法工作

## 分析
https://github.com/Lazy-Bing-Server/WhereIs-MCDR/blob/c3ca30a0fc7c1d517d9f96f849be052016d9b714/where_is/online_players.py#L16

此变量仅会在服务器启动时设置为True
https://github.com/Lazy-Bing-Server/WhereIs-MCDR/blob/c3ca30a0fc7c1d517d9f96f849be052016d9b714/where_is/online_players.py#L63-L67

https://github.com/Lazy-Bing-Server/WhereIs-MCDR/blob/c3ca30a0fc7c1d517d9f96f849be052016d9b714/where_is/online_players.py#L80-L83

如果服务器已经启动, 重载插件后插件实例被重新创建, 此时只要不重启服务器, 此变量就永远为False. 此时玩家加入/退出游戏均无法更改玩家列表

## 修复

1. 在插件被加载且服务器已经完全启动时调用 `__enable_player_join()`
2. 将此处代码中的`SERVER_START`修改为`SERVER_STARTUP`, 因为在服务器完全启动前没有任何人可以加入游戏
https://github.com/Lazy-Bing-Server/WhereIs-MCDR/blob/c3ca30a0fc7c1d517d9f96f849be052016d9b714/where_is/online_players.py#L80-L83

3. 添加`__disable_player_join()`(与`__enable_player_join()`作用相反), 并在服务器停止时调用

## 环境
MCDR `2.14.7`
where_is `2.2.1`